### PR TITLE
Middleware auth bind global

### DIFF
--- a/lib/endpoint_manager.js
+++ b/lib/endpoint_manager.js
@@ -17,10 +17,9 @@ var EndpointManager = module.exports.EndpointManager = function(options) {
 
   this.endpoint_modules = {};
 
-  this.options.auth = options.auth || { method: 'httpSignature', provider: 'sqlite3', dbstring: 'sqlite3://data//keys.db' };
-
-  if (this.options.auth !== false && typeof(this.options.auth) !== 'object') {
-    throw new Error('auth either must be false or an object containing method, provider, dbstring');
+  this.options.auth = options.auth || false;
+  if (this.options.auth !== false && typeof(this.options.auth) !== 'function') {
+    throw new Error('auth either must be false or a restify middleware function');
   }
 
   if (typeof(this.options.endpoint_args) == "undefined") {
@@ -120,20 +119,7 @@ EndpointManager.prototype.createRoutes = function(server) {
   var allowed_methods = { 'GET' : true, 'POST' : true, 'PUT' : true, 'DEL' : true, 'HEAD': true };
 
   this.endpoints.forEach(function(endpoint) {
-   
-    // TODO: implement authentication middleware
-    // DISABLED -- need to implement better
-    /*
-    if (endpoint.auth == 'httpSignature') {
-      if (self.options.auth.method === 'httpSignature') {
-        middleware.push(available_middleware.httpSignature(endpoint, self.options.auth));
-      }
-      else {
-        throw new Error(self.options.auth.method + ' not supported for authentication');
-      }
-    }
-    */
- 
+
     // Create a list of methods for this endpoint.
     var methods = endpoint.method;
     if (methods.constructor.name !== 'Array') {
@@ -164,6 +150,10 @@ EndpointManager.prototype.createRoutes = function(server) {
         versions.forEach(function(version) {
           // Create a middleware chain.
           var middleware = [];
+
+          if (typeof(self.options.auth) == 'function') {
+            middleware.push(self.options.auth.bind(endpoint));
+          }
  
           // If we require input validation for this endpoint,
           // add a validator middleware to the chain.


### PR DESCRIPTION
this might not have been what you were thinking of doing for auth middleware but here goes:
- this adds the possibility for setting a global auth middleware (for all endpoints) or setting the auth middleware at the the individual endpoint.
- this can be used in combination with either `requireAuth` (https://github.com/dweinstein/restify-endpoints-auth/blob/dev/lib/auth.js#L29) or `endpointAuth` (https://github.com/dweinstein/restify-endpoints-auth/blob/dev/lib/auth.js#L31) which basically allows either forcing all EPs to use auth, or leaving it to the endpoint to set `auth: true`.

I'll be merging that `dev` branch in my `restify-endpoints-auth` my `master` shortly.
